### PR TITLE
fix `logout!` when called with scope

### DIFF
--- a/lib/rails_warden/authentication.rb
+++ b/lib/rails_warden/authentication.rb
@@ -33,7 +33,7 @@ module RailsWarden
     # :api: public
     def logout!(scope: nil)
       if scope
-        warden.logout(scope: scope)
+        warden.logout(scope)
         warden.clear_strategies_cache!(scope: scope)
       else
         warden.logout


### PR DESCRIPTION
`Warden::Proxy#logout` takes a list of scopes and not a options hash like `login!` (https://github.com/wardencommunity/warden/blob/v1.2.7/lib/warden/proxy.rb#L255)