### PR TITLE
Fix for 'Unable to autoload constant Engine'

### DIFF
--- a/lib/rails_warden/engine.rb
+++ b/lib/rails_warden/engine.rb
@@ -2,6 +2,6 @@ require 'rails_warden/compat'
 
 module RailsWarden
   class Engine < ::Rails::Engine
-    config.eager_load_paths += Dir["#{config.root}/lib/**/"]
+    paths.add 'lib', eager_load: true
   end
 end


### PR DESCRIPTION
**WHY**
Was running into issues loading the Engine. `LoadError (Unable to autoload constant Engine,  ....`
Similar to this issue here: https://github.com/nsarno/knock/issues/5#issuecomment-288234691

**FIX**
Fix was to change the load path as per the linked comment.