### PR TITLE
Compatibility with Rails 6 and Zeitwerk loader

### DIFF
--- a/lib/rails_warden/engine.rb
+++ b/lib/rails_warden/engine.rb
@@ -2,6 +2,6 @@ require 'rails_warden/compat'
 
 module RailsWarden
   class Engine < ::Rails::Engine
-    paths.add 'lib', eager_load: true
+    config.autoload_paths << File.expand_path("../..", __dir__)
   end
 end


### PR DESCRIPTION
This change seems to fix the problem in Rails 6 `production` env, when zeitwerk tries to eager-load all the code and can't find the constants RailsWarden::Version. I didn't have any problems in `development` env, for some reason, though.

```
[...]
/home/florian/.rvm/gems/ruby-2.6.5@default/gems/zeitwerk-2.4.0/lib/zeitwerk/loader/callbacks.rb:17:in `on_file_autoloaded': expected file /home/florian/.rvm/
gems/ruby-2.6.5@default/bundler/gems/rails_warden-fb45d162be44/lib/rails_warden/version.rb to define constant RailsWarden::Version, but didn't (Zeitwerk::Nam
eError)